### PR TITLE
Add homebrew formula (1.0.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     rev: 68e8b45440415753fff70a312ece8da92ba85b4a # frozen: v1.5.0
     hooks:
       - id: detect-secrets
-        args: ["--exclude-lines", '\${.*}', "--exclude-files", '.*pkg\.recipe|\.pre-commit-config.yaml']
+        args: ["--exclude-lines", '\${.*}', "--exclude-files", '.*pkg\.recipe|\.pre-commit-config.yaml|Formula/.*\.rb']
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: a30f0d816e5062a67d87c8de753cfe499672b959 # frozen: v1.5.5

--- a/Formula/kst.rb
+++ b/Formula/kst.rb
@@ -1,0 +1,124 @@
+class Kst < Formula
+  include Language::Python::Virtualenv
+
+  desc "Local management of Kandji custom resources"
+  homepage "https://github.com/kandji-inc/kst"
+  url "https://files.pythonhosted.org/packages/44/e3/e3f41d2802b4b8a225af1e07cefc5b66619c3e7d2a45091f46feed37ab2f/kst-1.0.1.tar.gz"
+  sha256 "212355151447537b4a7968fcff766241c685d79eb3960b244c1080f2a4bfba0c"
+  license "MIT"
+  head "https://github.com/kandji-inc/kst.git", branch: "main"
+
+  depends_on "rust" => :build # for pydantic-core
+  depends_on "python@3.13"
+
+  resource "annotated-types" do
+    url "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
+    sha256 "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"
+  end
+
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz"
+    sha256 "0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"
+  end
+
+  resource "charset-normalizer" do
+    url "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz"
+    sha256 "5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz"
+    sha256 "ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
+  end
+
+  resource "markdown-it-py" do
+    url "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+    sha256 "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
+  end
+
+  resource "mdurl" do
+    url "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+    sha256 "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+  end
+
+  resource "platformdirs" do
+    url "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz"
+    sha256 "3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"
+  end
+
+  resource "pydantic" do
+    url "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz"
+    sha256 "32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d"
+  end
+
+  resource "pydantic-core" do
+    url "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz"
+    sha256 "7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"
+  end
+
+  resource "pygments" do
+    url "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz"
+    sha256 "61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
+    sha256 "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"
+  end
+
+  resource "rich" do
+    url "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz"
+    sha256 "82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"
+  end
+
+  resource "ruamel-yaml" do
+    url "https://files.pythonhosted.org/packages/ea/46/f44d8be06b85bc7c4d8c95d658be2b68f27711f279bf9dd0612a5e4794f5/ruamel.yaml-0.18.10.tar.gz"
+    sha256 "20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58"
+  end
+
+  resource "shellingham" do
+    url "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz"
+    sha256 "8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
+  end
+
+  resource "typer" do
+    url "https://files.pythonhosted.org/packages/98/1a/5f36851f439884bcfe8539f6a20ff7516e7b60f319bbaf69a90dc35cc2eb/typer-0.15.3.tar.gz"
+    sha256 "818873625d0569653438316567861899f7e9972f2e6e0c16dab608345ced713c"
+  end
+
+  resource "typing-extensions" do
+    url "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz"
+    sha256 "e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"
+  end
+
+  resource "typing-inspection" do
+    url "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz"
+    sha256 "9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz"
+    sha256 "414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match "kst, version #{version}", shell_output("#{bin}/kst --version")
+    system "git", "config", "--global", "user.name", "Kandji Sync Toolkit"
+    system "git", "config", "--global", "user.email", "kst@kandji.invalid"
+    system bin/"kst", "new", testpath/"test-repo"
+    system "git", "-C", testpath/"test-repo", "rev-parse", "--is-inside-work-tree"
+    system bin/"kst", "profile", "new", "--output", testpath/"test-repo/profiles", "--name", "test-profile"
+    system bin/"kst", "profile", "list", "--repo", testpath/"test-repo", "--local"
+    system bin/"kst", "script", "new", "--output", testpath/"test-repo/scripts", "--name", "test-script"
+    system bin/"kst", "script", "list", "--repo", testpath/"test-repo", "--local"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 > More information at [brew.sh](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```sh
+brew tap kandji-inc/kst https://github.com/kandji-inc/kst.git
 brew install kst
 ```
 


### PR DESCRIPTION
## ❓ _Why This Change_
- Adding a homebrew formula for `kst` version 1.0.1

## 🆕 _What Changed_
- Added new `kst.rb` homebrew formula to the Formula directory
- Updated `README.md` with install instructions on tapping kandji-inc/kst
- Updated `detect-secrets` hook with exclusion for formula as they contain hashes

## 🧪 _Test Results_

```
❯ brew test kst
==> Testing kandji-inc/kst/kst
==> /opt/homebrew/Cellar/kst/1.0.1/bin/kst --version
==> git config --global user.name Kandji Sync Toolkit
==> git config --global user.email kst@kandji.invalid
==> /opt/homebrew/Cellar/kst/1.0.1/bin/kst new /private/tmp/kst-test-20250508-21825-7sl6jr/test-repo
==> git -C /private/tmp/kst-test-20250508-21825-7sl6jr/test-repo rev-parse --is-inside-work-tree
==> /opt/homebrew/Cellar/kst/1.0.1/bin/kst profile new --output /private/tmp/kst-test-20250508-21825-7sl6jr/test-repo/pr
==> /opt/homebrew/Cellar/kst/1.0.1/bin/kst profile list --repo /private/tmp/kst-test-20250508-21825-7sl6jr/test-repo --l
==> /opt/homebrew/Cellar/kst/1.0.1/bin/kst script new --output /private/tmp/kst-test-20250508-21825-7sl6jr/test-repo/scr
==> /opt/homebrew/Cellar/kst/1.0.1/bin/kst script list --repo /private/tmp/kst-test-20250508-21825-7sl6jr/test-repo --lo
```

## :shipit: _Ready Checks_
- [x] These changes have been carefully tested across multiple macOS versions
- [x] Where logical, code updates include inline comments/docstrings
