### PR TITLE
handle case where show_in_self_service key does not exist in api response

### DIFF
--- a/src/kst/api/payload.py
+++ b/src/kst/api/payload.py
@@ -32,7 +32,7 @@ class CustomProfilePayload(BaseModel):
 class CustomScriptPayload(BaseModel):
     """Payload model for custom script API endpoints."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", json_schema_extra={"exclude_unset_fields": True})
 
     id: Annotated[str, AfterValidator(lambda value: value.lower())]
     name: str
@@ -43,7 +43,7 @@ class CustomScriptPayload(BaseModel):
     remediation_script: str
     created_at: str
     updated_at: str
-    show_in_self_service: bool
+    show_in_self_service: bool | None = False
     self_service_category_id: str | None = None
     self_service_recommended: bool | None = None
 

--- a/src/kst/api/payload.py
+++ b/src/kst/api/payload.py
@@ -32,7 +32,7 @@ class CustomProfilePayload(BaseModel):
 class CustomScriptPayload(BaseModel):
     """Payload model for custom script API endpoints."""
 
-    model_config = ConfigDict(extra="forbid", json_schema_extra={"exclude_unset_fields": True})
+    model_config = ConfigDict(extra="forbid")
 
     id: Annotated[str, AfterValidator(lambda value: value.lower())]
     name: str

--- a/src/kst/api/profiles.py
+++ b/src/kst/api/profiles.py
@@ -42,7 +42,7 @@ class CustomProfilesResource(ResourceBase):
             response = self.client.get(next_page)
 
             # Parse bytes content to CustomProfilePayloadList or raise ValidationError
-            profile_list = PayloadList.model_validate_json(response.content)
+            profile_list = PayloadList[CustomProfilePayload].model_validate_json(response.content)
 
             all_results.count = profile_list.count
             all_results.results.extend(profile_list.results)

--- a/src/kst/api/scripts.py
+++ b/src/kst/api/scripts.py
@@ -55,7 +55,7 @@ class CustomScriptsResource(ResourceBase):
             response = self.client.get(next_page)
 
             # Parse bytes content to CustomScriptPayloadList or raise ValidationError
-            script_list = PayloadList.model_validate_json(response.content)
+            script_list = PayloadList[CustomScriptPayload].model_validate_json(response.content)
 
             all_results.count = script_list.count
             all_results.results.extend(script_list.results)


### PR DESCRIPTION
So I set this up for testing and found that I had one script where for some reason `show_in_self_service` was missing from the API response.

I have added handling for this edge case to resolve the issue, with the behaviour to set the value to false in the local repo if the value does not exist remotely.

I also had some issues with nailing down the problem as when using `PayloadList.model_validate_json` it was not being specified which `ApiPayloadType` to use, so it was defaulting to `CustomProfilePayload` when the schema wasn't matching. I'm not super familiar with how pydantic should handle this, but was able to resolve by implicitly specifying the `ApiPayloadType`.

You can see this below where despite using `kst script pull --all` it gets a validation error for `CustomProfilePayload`

Before:
```shell
> kst script pull --all
An error occurred while fetching: 7 validation errors for PayloadList
results.0.CustomProfilePayload.profile
  Field required 
    For further information visit https://errors.pydantic.dev/2.11/v/missing
results.0.CustomProfilePayload.mdm_identifier
  Field required 
    For further information visit https://errors.pydantic.dev/2.11/v/missing
results.0.CustomProfilePayload.execution_frequency
  Extra inputs are not permitted 
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
results.0.CustomProfilePayload.restart
  Extra inputs are not permitted 
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
results.0.CustomProfilePayload.script
  Extra inputs are not permitted 
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
results.0.CustomProfilePayload.remediation_script
  Extra inputs are not permitted 
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
results.0.CustomScriptPayload.show_in_self_service
  Field required 
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```
After:
```shell
> kst script pull --all
Pulling 27 changes from Kandji...
(Removed for privacy)
Pull operation complete!

Updated Item Summary                  
                                      
  Action         Success    Failure   
 ──────────────────────────────────── 
  Created        27         0         
```

Ran all tests and all are passing with my changes:
```shell
uv run poe test
Poe => uv run pytest --quiet --showlocals
...............................................................................................................................................s.s..s...s....ss.....s..s..s...s......s......................................................................... [ 58%]
......................................................................................................................................................................................                                                                          [100%]
426 passed, 11 skipped in 26.05s
```