### PR TITLE
Add format option on pull

### DIFF
--- a/src/kst/cli/script/pull.py
+++ b/src/kst/cli/script/pull.py
@@ -26,7 +26,7 @@ from kst.cli.utility import (
 )
 from kst.console import OutputConsole, epilog_text
 from kst.exceptions import GitRepositoryError
-from kst.repository import CustomScript, RepositoryDirectory
+from kst.repository import CustomScript, InfoFormat, RepositoryDirectory
 
 from .common import (
     ScriptAllOption,
@@ -56,6 +56,15 @@ CleanOption = Annotated[
         help="[red]Delete[/] local scripts which are not present in Kandji.",
     ),
 ]
+FormatOption = Annotated[
+    InfoFormat,
+    typer.Option(
+        "--format",
+        "-f",
+        help="The output format for new info files when pulling.",
+        rich_help_panel="Output",
+    ),
+]
 
 
 @app.command(name="pull", no_args_is_help=True, epilog=epilog_text)
@@ -69,6 +78,7 @@ def pull_scripts(
     dry_run: DryRunOption = False,
     tenant_url: KandjiTenantOption = None,
     api_token: ApiTokenOption = None,
+    format: FormatOption = InfoFormat.PLIST,
 ):
     """
     Pull remote custom scripts changes from Kandji.
@@ -86,6 +96,8 @@ def pull_scripts(
     If --clean is used, scripts will be deleted from the local repository if they
     are not in Kandji. --clean can only be used with --all.
 
+    If --format is used, newly created script info files will use the specified format
+    (plist, json, or yaml). Existing files will retain their current format.
     """
 
     repo = validate_repo_path(repo=repo_str, subdir=RepositoryDirectory.SCRIPTS)
@@ -138,6 +150,11 @@ def pull_scripts(
     # Exit with error if any scripts were not found
     verify_all_ids_found(member_ids=map(str, script_ids), local_repo=local_repo, remote_repo=remote_repo)
 
+    # Set format for new script files
+    for member_id, member in remote_repo.items():
+        if member_id not in local_repo:
+            member.info.format = format
+            
     # Compare local and remote scripts
     changes = filter_changes(local_repo=local_repo, remote_repo=remote_repo)
 


### PR DESCRIPTION
## ❓ _Why This Change_
- I don't like using plist files, so I wanted to be able to pull all objects as yaml or json

## 🆕 _What Changed_
- I have added the additional option `--format` to the `pull` command, which will create net new info files as the specified format. It won't affect existing info files.

## 🧪 _Test Results_
```shell
uv run poe test
      Built kst @ file:///Users/stevenb/Work/kst
Uninstalled 1 package in 1ms
Installed 1 package in 1ms
Poe => uv run pytest --quiet --showlocals
........................................................................................................................................... [ 31%]
....s.s..s...s....ss.....s..s..s...s......s................................................................................................ [ 63%]
........................................................................................................................................... [ 95%]
....................                                                                                                                        [100%]
426 passed, 11 skipped in 28.08s
```

## :shipit: _Ready Checks_
- [ ] These changes have been carefully tested across multiple macOS versions
- [ ] Where logical, code updates include inline comments/docstrings
