### PR TITLE
fix(git): add start_new_session=True to subprocess.run in git()

### DIFF
--- a/src/kst/git.py
+++ b/src/kst/git.py
@@ -93,7 +93,7 @@ def git(
     cmd.extend(args)
     console.debug(f"Executing git command: {' '.join(cmd)}")
 
-    result = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    result = subprocess.run(cmd, check=False, text=True, capture_output=True, start_new_session=True)
     console.debug(f"Git command executed with exit code {result.returncode}")
 
     if expected_exit_code is not None and result.returncode != expected_exit_code:


### PR DESCRIPTION


🆕 What Changed
On macOS with Python 3.14 and OpenSSL 3.5.5, git subprocesses crash with SIGSEGV (exit code -11) when spawned after an HTTPS request has been made by the requests library. This is caused by posix_spawn inheriting corrupted process state from the SSL library, and affects all git operations that occur after the Kandji API ping (e.g. locate_root for profiles/scripts paths).
🧪 Test Results


:shipit: Ready Checks
 These changes have been carefully tested across multiple macOS versions
 Where logical, code updates include inline comments/docstrings

## ❓ _Why This Change_

On macOS with Python 3.14 and OpenSSL 3.5.5, git subprocesses crash with SIGSEGV (exit code -11) when spawned after an HTTPS request has been made by the requests library. This is caused by posix_spawn inheriting corrupted process state from the SSL library, and affects all git operations that occur after the Kandji API ping (e.g. locate_root for profiles/scripts paths).

## 🆕 _What Changed_

- Added start_new_session=True to the subprocess.run() call in the git() function
- This forces fork+exec instead of posix_spawn, creating a clean session for the child process and avoiding the crash

## 🧪 _Test Results_

```
Reproduced reliably on macOS (Apple Silicon) with:
- Python 3.14.3, OpenSSL 3.5.5
- git 2.54.0

Before fix: git exits -11 (SIGSEGV) after any requests HTTPS call
After fix: git exits 0 consistently

Verified via:
  import subprocess, requests
  requests.get('https://example.com')
  # Without fix: returncode=-11
  # With start_new_session=True: returncode=0
  subprocess.run(['git', 'rev-parse', '--show-toplevel'],
                 capture_output=True, start_new_session=True)
```

## :shipit: _Ready Checks_
- [ ] These changes have been carefully tested across multiple macOS versions
- [ ] Where logical, code updates include inline comments/docstrings
